### PR TITLE
Switch demo file to local copy

### DIFF
--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,3 +1,2 @@
 github:
   url: http://localhost:4000
-include: ['201541349349307794_public.xml']

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,6 @@ exclude: [
   'GEMFILE',
   '.gitignore',
   'LICENSE',
-  '201541349349307794_public.xml',
   'script',
   'vendor'
 ]

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
             </svg>
         </button>
         <p id="url-error"></p>
-        <p>Demo URL: <a href="https://s3.amazonaws.com/irs-form-990/201541349349307794_public.xml">https://s3.amazonaws.com/irs-form-990/201541349349307794_public.xml</a></p>
+        <p>Demo URL: <a href="{{ site.github.url }}/201541349349307794_public.xml">{{ site.github.url }}/201541349349307794_public.xml</a></p>
     </form>
     <div class="file-upload">
         <h2>OR</h2>


### PR DESCRIPTION
The original AWS repository is no longer available. Switch the demo file to pull from a locally-hosted copy of a 990 form.